### PR TITLE
Daedalean coding standards for operator overloading

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangTidyDaedaleanModule
   SwitchStatementCheck.cpp
   TernaryOperatorMustNotBeUsedCheck.cpp
   LambdaReturnTypeCheck.cpp
+  OperatorOverloadingCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -15,6 +15,7 @@
 #include "SwitchStatementCheck.h"
 #include "TernaryOperatorMustNotBeUsedCheck.h"
 #include "LambdaReturnTypeCheck.h"
+#include "OperatorOverloadingCheck.h"
 
 using namespace clang::ast_matchers;
 
@@ -38,6 +39,8 @@ public:
         "daedalean-ternary-operator-must-not-be-used");
     CheckFactories.registerCheck<LambdaReturnTypeCheck>(
         "daedalean-lambda-return-type");
+    CheckFactories.registerCheck<OperatorOverloadingCheck>(
+        "daedalean-operator-overloading");
   }
 };
 

--- a/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
@@ -195,6 +195,7 @@ void OperatorOverloadingCheck::checkReturnSelf(const Stmt *stmt) {
       checkReturnSelf(s);
     }
   }
+
   if (const auto ptr = llvm::dyn_cast<ReturnStmt>(stmt); ptr) {
     const auto expr = ptr->getRetValue();
     if (const auto uOp = llvm::dyn_cast<UnaryOperator>(expr); uOp) {
@@ -204,6 +205,7 @@ void OperatorOverloadingCheck::checkReturnSelf(const Stmt *stmt) {
     } else {
       diag(ptr->getBeginLoc(), "Assignment operator must return reference to this");
     }
+    // If there is no return at all compiler will generate warning/error
   }
 
 }

--- a/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
@@ -19,7 +19,7 @@ namespace daedalean {
 namespace  {
 AST_MATCHER(FunctionDecl, isOverloadedOperator) {
   if (const auto *CXXMethodNode = dyn_cast<CXXMethodDecl>(&Node)) {
-    if (CXXMethodNode->getParent()->isLambda())
+    if (CXXMethodNode->isImplicit())
       return false;
   }
   return Node.isOverloadedOperator();

--- a/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
@@ -1,0 +1,213 @@
+//===--- OperatorOverloadingCheck.cpp - clang-tidy ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "OperatorOverloadingCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+namespace  {
+AST_MATCHER(FunctionDecl, isOverloadedOperator) {
+  if (const auto *CXXMethodNode = dyn_cast<CXXMethodDecl>(&Node)) {
+    if (CXXMethodNode->getParent()->isLambda())
+      return false;
+  }
+  return Node.isOverloadedOperator();
+}
+
+bool hasOperator(const DeclContext * ctx, OverloadedOperatorKind kind, const QualType & type, const QualType & arg) {
+  for (const auto & d: ctx->decls()) {
+    if (const auto func = llvm::dyn_cast<FunctionDecl>(d); func) {
+      if (!func->isOverloadedOperator() || func->getOverloadedOperator() != kind) {
+        continue;
+      }
+
+
+      if (func->getParamDecl(0)->getType().getNonReferenceType().getUnqualifiedType() != type.getNonReferenceType().getUnqualifiedType()) {
+        continue;
+      }
+
+      if (func->getParamDecl(1)->getType() != arg) {
+        continue;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool hasOperator(const CXXRecordDecl * cls, OverloadedOperatorKind kind, const QualType & arg, bool onlyConst = false) {
+  for (const auto & m: cls->methods()) {
+    if (!m->isOverloadedOperator() ||
+        m->getOverloadedOperator() != kind) {
+      continue;
+    }
+
+    if (onlyConst && !m->isConst()) {
+      continue;
+    }
+
+    if (m->getParamDecl(0)->getType() != arg) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return hasOperator(cls->getParent(), kind, cls->getTypeForDecl()->getCanonicalTypeUnqualified(), arg);
+}
+
+bool hasOperator(const FunctionDecl * function, OverloadedOperatorKind kind) {
+  if (auto method = llvm::dyn_cast<CXXMethodDecl>(function); method) {
+    return hasOperator(method->getParent(), kind, function->getParamDecl(0)->getType());
+  } else {
+    const auto firstType = function->getParamDecl(0)->getType();
+    if (firstType.getNonReferenceType()->isRecordType()) {
+      return hasOperator(firstType.getNonReferenceType()->getAsCXXRecordDecl(), kind, function->getParamDecl(1)->getType());
+    } else {
+      return hasOperator(function->getParent(), kind, firstType.getNonReferenceType(), function->getParamDecl(1)->getType());
+    }
+  }
+}
+
+}
+
+void OperatorOverloadingCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(functionDecl(isOverloadedOperator()).bind("x"), this);
+}
+
+void OperatorOverloadingCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *function = Result.Nodes.getNodeAs<FunctionDecl>("x");
+  const auto *method = llvm::dyn_cast<CXXMethodDecl>(function);
+
+  switch (function->getOverloadedOperator()) {
+  case OO_Equal:
+    [[fallthrough]];
+  case OO_PlusEqual:
+    [[fallthrough]];
+  case OO_MinusEqual:
+    [[fallthrough]];
+  case OO_PipeEqual:
+    [[fallthrough]];
+  case OO_AmpEqual:
+    [[fallthrough]];
+  case OO_CaretEqual:
+    [[fallthrough]];
+  case OO_LessLessEqual:
+    [[fallthrough]];
+  case OO_GreaterGreaterEqual:
+    [[fallthrough]];
+  case OO_SlashEqual:
+    [[fallthrough]];
+  case OO_StarEqual:
+    [[fallthrough]];
+  case OO_PercentEqual: {
+    checkReturnSelf(method->getDefinition()->getBody());
+    break;
+  }
+  case OO_Amp:
+      if (function->getNumParams() != 0) { // Skip binary form
+        break;
+      }
+      [[fallthrough]];
+  case OO_AmpAmp:
+    [[fallthrough]];
+  case OO_PipePipe:
+    diag(function->getBeginLoc(), "overloading %0 is disallowed") << function;
+    break;
+  case OO_Subscript:
+    if (!method->isConst()) {
+      if (hasOperator(method->getParent(), OO_Subscript,
+                      function->getParamDecl(0)->getType(), true)) {
+        break;
+      }
+
+      diag(function->getBeginLoc(), "If operator[] overloaded with non-const version, const version MUST be present.") << function;
+    }
+    break;
+  case OO_EqualEqual:
+    checkOperatorPair(function, OO_ExclaimEqual, "If == overloaded, != MUST be overloaded as well");
+    if (hasOperator(function, OO_Less) && !hasOperator(function, OO_LessEqual)) {
+      diag(function->getBeginLoc(), "If == and < overloaded, <= MUST be overloaded as well") << function;
+    }
+    break;
+  case OO_ExclaimEqual:
+     checkOperatorPair(function, OO_EqualEqual, "If != overloaded, == MUST be overloaded as well");
+    break;
+  case OO_Less:
+    checkOperatorPair(function, OO_Greater, "If < overloaded, > MUST be overloaded as well");
+    break;
+  case OO_Greater:
+    checkOperatorPair(function, OO_Less, "If > overloaded, < MUST be overloaded as well");
+    break;
+  case OO_LessEqual:
+    checkOperatorPair(function, OO_GreaterEqual, "If <= overloaded, >= MUST be overloaded as well");
+    checkOperatorPair(function, OO_EqualEqual, "If <= overloaded, == MUST be overloaded as well");
+    break;
+  case OO_GreaterEqual:
+    checkOperatorPair(function, OO_LessEqual, "If >= overloaded, <= MUST be overloaded as well");
+    checkOperatorPair(function, OO_EqualEqual, "If >= overloaded, == MUST be overloaded as well");
+    break;
+  default:
+    break;
+  };
+}
+
+void OperatorOverloadingCheck::checkOperatorPair(const FunctionDecl * function, OverloadedOperatorKind kind, const std::string & message) {
+  if (hasOperator(function, kind)) {
+    return;
+  }
+
+  diag(function->getBeginLoc(), message) << function;
+}
+void OperatorOverloadingCheck::checkReturnSelf(const Stmt *stmt) {
+  if (!stmt) {
+    return;
+  }
+
+  if (const auto ptr = llvm::dyn_cast<ForStmt>(stmt); ptr) {
+    checkReturnSelf(ptr->getBody());
+  }
+  if (const auto ptr = llvm::dyn_cast<WhileStmt>(stmt); ptr) {
+    checkReturnSelf(ptr->getBody());
+  }
+  if (const auto ptr = llvm::dyn_cast<DoStmt>(stmt); ptr) {
+    checkReturnSelf(ptr->getBody());
+  }
+  if (const auto ptr = llvm::dyn_cast<IfStmt>(stmt); ptr) {
+    checkReturnSelf(ptr->getThen());
+    checkReturnSelf(ptr->getElse());
+  }
+  if (const auto ptr = llvm::dyn_cast<CompoundStmt>(stmt); ptr) {
+    for (const auto s : ptr->body()) {
+      checkReturnSelf(s);
+    }
+  }
+  if (const auto ptr = llvm::dyn_cast<ReturnStmt>(stmt); ptr) {
+    const auto expr = ptr->getRetValue();
+    if (const auto uOp = llvm::dyn_cast<UnaryOperator>(expr); uOp) {
+      if (uOp->getOpcode() != UO_Deref || !llvm::isa<CXXThisExpr>(uOp->getSubExpr())) {
+        diag(ptr->getBeginLoc(), "Assignment operator must return reference to this");
+      }
+    } else {
+      diag(ptr->getBeginLoc(), "Assignment operator must return reference to this");
+    }
+  }
+
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.h
@@ -1,0 +1,38 @@
+//===--- OperatorOverloadingCheck.h - clang-tidy ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_OPERATOROVERLOADINGCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_OPERATOROVERLOADINGCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Daedalean CS.R.41 Operator overloading
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-operator-overloading.html
+class OperatorOverloadingCheck : public ClangTidyCheck {
+public:
+  OperatorOverloadingCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+  void checkOperatorPair(const FunctionDecl * function, OverloadedOperatorKind kind, const std::string & message);
+  void checkReturnSelf(const Stmt *stmt);
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_OPERATOROVERLOADINGCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -231,6 +231,11 @@ New checks
 
   FIXME: add release notes.
 
+- New :doc:`daedalean-operator-overloading
+  <clang-tidy/checks/daedalean-operator-overloading>` check.
+
+  FIXME: add release notes.
+
 - New :doc:`readability-suspicious-call-argument
   <clang-tidy/checks/readability-suspicious-call-argument>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-operator-overloading.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-operator-overloading.rst
@@ -1,0 +1,17 @@
+.. title:: clang-tidy - daedalean-operator-overloading
+
+daedalean-operator-overloading
+==============================
+
+Daedalean coding standards for operator overloading
+ - Operators , && || MUST not be overloaded.
+ - Unary operator & MUST not be overloaded.
+ - If operator[] overloaded with non-const version, const version MUST be present.
+ - Assignment operators MUST return reference to self.
+ - Assignment operators MUST check if self-assignment takes place.
+ - When comparison operators overloaded, set of operators MUST be complete:
+   - If == overloaded, != MUST be overloaded as well
+   - If < overloaded, > MUST be overloaded as well
+   - If <= overloaded, >= MUST be overloaded as well
+   - If <= are overloaded, == MUST be overloaded
+   - If < and == are overloaded, <= MUST be overloaded

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-operator-overloading.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-operator-overloading.rst
@@ -8,7 +8,6 @@ Daedalean coding standards for operator overloading
  - Unary operator & MUST not be overloaded.
  - If operator[] overloaded with non-const version, const version MUST be present.
  - Assignment operators MUST return reference to self.
- - Assignment operators MUST check if self-assignment takes place.
  - When comparison operators overloaded, set of operators MUST be complete:
    - If == overloaded, != MUST be overloaded as well
    - If < overloaded, > MUST be overloaded as well

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -172,6 +172,7 @@ Clang-Tidy Checks
    `daedalean-switch-statement <daedalean-switch-statement.html>`_,
    `daedalean-ternary-operator-must-not-be-used <daedalean-ternary-operator-must-not-be-used.html>`_,
    `daedalean-lambda-return-type <daedalean-lambda-return-type.html>`_, "Yes"
+   `daedalean-operator-overloading <daedalean-operator-overloading.html>`_,
    `darwin-avoid-spinlock <darwin-avoid-spinlock.html>`_,
    `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_, "Yes"
    `fuchsia-default-arguments-calls <fuchsia-default-arguments-calls.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-operator-overloading.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-operator-overloading.cpp
@@ -1,0 +1,87 @@
+// RUN: %check_clang_tidy %s daedalean-operator-overloading %t
+
+class C {
+public:
+    bool operator &&(const C&) const;
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator&&' is disallowed [daedalean-operator-overloading]
+    bool operator ||(const C&) const;
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator||' is disallowed [daedalean-operator-overloading]
+    C* operator&();
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator&' is disallowed [daedalean-operator-overloading]
+    C operator &(const C&);
+    int operator[](int);
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
+
+    bool operator==(const C&);
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If == overloaded, != MUST be overloaded as well [daedalean-operator-overloading]
+    bool operator!=(const int);
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If != overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+
+    bool operator==(float);
+    bool operator!=(float);
+
+    C & operator=(int a) {
+      if (a == 1) {
+        return *(new C);
+        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
+      } else if (a == 2) {
+        C * v = this;
+        return *v;
+        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
+      } else if (a == 3) {
+        C &v = *this;
+        return v;
+        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
+      }
+      return *this;
+    }
+};
+
+class C2 {
+    int operator[](int);
+    int operator[](int) const;
+    int operator[](int&);
+    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
+    bool operator==(char);
+};
+
+bool operator==(const C2&, const C&);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If == overloaded, != MUST be overloaded as well [daedalean-operator-overloading]
+bool operator!=(const C2&, const int);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If != overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+
+bool operator<(const C2&, const C&);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If < overloaded, > MUST be overloaded as well [daedalean-operator-overloading]
+bool operator>(const C2&, const int);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If > overloaded, < MUST be overloaded as well [daedalean-operator-overloading]
+
+bool operator<=(const C2&, const C&);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If <= overloaded, >= MUST be overloaded as well [daedalean-operator-overloading]
+bool operator>=(const C2&, const int);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If >= overloaded, <= MUST be overloaded as well [daedalean-operator-overloading]
+//  CHECK-MESSAGES: :[[@LINE-2]]:1: warning: If >= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+
+bool operator<=(const C2&, float);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If <= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+bool operator>=(const C2&, float);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If >= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+
+bool operator<(const C2&, double);
+bool operator>(const C2&, double);
+bool operator!=(const C2&, double);
+bool operator==(const C2&, double);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If == and < overloaded, <= MUST be overloaded as well [daedalean-operator-overloading]
+
+bool operator!=(const C2&, char);
+
+bool operator==(const C2&, const C2&);
+bool operator!=(const C2&, const C2&);
+bool operator<(const C2&, const C2&);
+bool operator>(const C2&, const C2&);
+bool operator<=(const C2&, const C2&);
+bool operator>=(const C2&, const C2&);
+
+bool operator &&(const C&, const C&);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: overloading 'operator&&' is disallowed [daedalean-operator-overloading]
+bool operator ||(const C&, const C&);
+//  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: overloading 'operator||' is disallowed [daedalean-operator-overloading]


### PR DESCRIPTION
+ Operators , && || MUST not be overloaded.
+ Unary operator & MUST not be overloaded.
+ If operator[] overloaded with non-const version, const version MUST be present.
+ Assignment operators MUST return reference to self.
+ When comparison operators overloaded, set of operators MUST be complete:
 + If == overloaded, != MUST be overloaded as well
 + If < overloaded, > MUST be overloaded as well
 + If <= overloaded, >= MUST be overloaded as well
 + If <= are overloaded, == MUST be overloaded
 + If < and == are overloaded, <= MUST be overloaded

Relates: T10099