### PR TITLE
Daedalean coding standards for structs and classes

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -9,6 +9,8 @@ add_clang_library(clangTidyDaedaleanModule
   CommaOperatorMustNotBeUsedCheck.cpp
   DerivedClassesCheck.cpp
   LambdaImplicitCaptureCheck.cpp
+  StructsAndClassesCheck.cpp
+  ProtectedMustNotBeUsedCheck.cpp
   SwitchStatementCheck.cpp
   TernaryOperatorMustNotBeUsedCheck.cpp
   LambdaReturnTypeCheck.cpp

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -12,6 +12,8 @@
 #include "CommaOperatorMustNotBeUsedCheck.h"
 #include "DerivedClassesCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
+#include "ProtectedMustNotBeUsedCheck.h"
+#include "StructsAndClassesCheck.h"
 #include "SwitchStatementCheck.h"
 #include "TernaryOperatorMustNotBeUsedCheck.h"
 #include "LambdaReturnTypeCheck.h"
@@ -33,6 +35,10 @@ public:
         "daedalean-derived-classes");
     CheckFactories.registerCheck<LambdaImplicitCaptureCheck>(
         "daedalean-lambda-implicit-capture");
+    CheckFactories.registerCheck<ProtectedMustNotBeUsedCheck>(
+        "daedalean-protected-must-not-be-used");
+    CheckFactories.registerCheck<StructsAndClassesCheck>(
+        "daedalean-structs-and-classes");
     CheckFactories.registerCheck<SwitchStatementCheck>(
         "daedalean-switch-statement");
     CheckFactories.registerCheck<TernaryOperatorMustNotBeUsedCheck>(

--- a/clang-tools-extra/clang-tidy/daedalean/ProtectedMustNotBeUsedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/ProtectedMustNotBeUsedCheck.cpp
@@ -1,0 +1,32 @@
+//===--- ProtectedMustNotBeUsedCheck.cpp - clang-tidy ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ProtectedMustNotBeUsedCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void ProtectedMustNotBeUsedCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(accessSpecDecl().bind("x"), this);
+}
+
+void ProtectedMustNotBeUsedCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<AccessSpecDecl>("x");
+  if (MatchedDecl->getAccess() == AS_protected) {
+    diag(MatchedDecl->getLocation(), "protected modifier must not be used");
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/ProtectedMustNotBeUsedCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/ProtectedMustNotBeUsedCheck.h
@@ -1,0 +1,34 @@
+//===--- ProtectedMustNotBeUsedCheck.h - clang-tidy -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_PROTECTEDMUSTNOTBEUSEDCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_PROTECTEDMUSTNOTBEUSEDCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Daedalean coding standards for structs and classes
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-protected-must-not-be-used.html
+class ProtectedMustNotBeUsedCheck : public ClangTidyCheck {
+public:
+  ProtectedMustNotBeUsedCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_PROTECTEDMUSTNOTBEUSEDCHECK_H

--- a/clang-tools-extra/clang-tidy/daedalean/StructsAndClassesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/StructsAndClassesCheck.cpp
@@ -1,0 +1,64 @@
+//===--- StructsAndClassesCheck.cpp - clang-tidy --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "StructsAndClassesCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void StructsAndClassesCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxRecordDecl(hasDefinition()).bind("x"), this);
+}
+
+void StructsAndClassesCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<CXXRecordDecl>("x");
+
+  if (!MatchedDecl->isStruct() && !MatchedDecl->isClass()) {
+    // Skip enums, unions etc
+    return;
+  }
+
+  if (MatchedDecl->isPOD()) {
+    if (!MatchedDecl->isStruct()) {
+      diag(MatchedDecl->getBeginLoc(), "POD type must be declared as struct")
+          << MatchedDecl;
+      diag(MatchedDecl->getBeginLoc(), "use struct", DiagnosticIDs::Note)
+          << FixItHint::CreateReplacement(MatchedDecl->getBeginLoc(), "struct");
+    }
+  } else {
+    if (!MatchedDecl->isClass()) {
+      diag(MatchedDecl->getBeginLoc(), "Non-POD type must be declared as class")
+          << MatchedDecl;
+      diag(MatchedDecl->getBeginLoc(), "use class", DiagnosticIDs::Note)
+          << FixItHint::CreateReplacement(MatchedDecl->getBeginLoc(), "class");
+    }
+  }
+
+  if (MatchedDecl->isClass()) {
+    for (const auto * field: MatchedDecl->fields()) {
+      if (field->getType().isConstQualified()) {
+        continue;
+      }
+      if (field->getAccess() != AS_private && field->getAccess() != AS_none) {
+        diag(field->getBeginLoc(), "All non-const data members of class MUST be private")
+            << MatchedDecl;
+        diag(field->getBeginLoc(), "Make field private", DiagnosticIDs::Note)
+            << FixItHint::CreateInsertion(field->getBeginLoc(), "private:");
+      }
+    }
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/StructsAndClassesCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/StructsAndClassesCheck.h
@@ -1,0 +1,34 @@
+//===--- StructsAndClassesCheck.h - clang-tidy ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_STRUCTSANDCLASSESCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_STRUCTSANDCLASSESCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Daedalean coding standards for structs and classes
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-structs-and-classes.html
+class StructsAndClassesCheck : public ClangTidyCheck {
+public:
+  StructsAndClassesCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_STRUCTSANDCLASSESCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -220,6 +220,12 @@ New checks
 
   FIXME: add release notes.
 
+- New :doc:`daedalean-protected-must-not-be-used
+  <clang-tidy/checks/daedalean-protected-must-not-be-used>` check.
+
+- New :doc:`daedalean-structs-and-classes
+  <clang-tidy/checks/daedalean-structs-and-classes>` check.
+
 - New :doc:`daedalean-switch-statement
   <clang-tidy/checks/daedalean-switch-statement>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-protected-must-not-be-used.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-protected-must-not-be-used.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - daedalean-protected-must-not-be-used
+
+daedalean-protected-must-not-be-used
+====================================
+
+Daedalean coding standards for structs and classes
+
+1. "protected" modifier MUST NOT be used

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-structs-and-classes.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-structs-and-classes.rst
@@ -1,0 +1,11 @@
+.. title:: clang-tidy - daedalean-structs-and-classes
+
+daedalean-structs-and-classes
+=============================
+
+Daedalean coding standards for structs and classes
+
+1. POD types MUST be declared as struct.
+2. Non-POD types MUST be declared as class.
+3. All non-const data members of class MUST be private.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -169,6 +169,8 @@ Clang-Tidy Checks
    `daedalean-derived-classes <daedalean-derived-classes.html>`_, "Yes"
    `daedalean-comma-operator-must-not-be-used <daedalean-comma-operator-must-not-be-used.html>`_,
    `daedalean-lambda-implicit-capture <daedalean-lambda-implicit-capture.html>`_,
+   `daedalean-protected-must-not-be-used <daedalean-protected-must-not-be-used.html>`_,
+   `daedalean-structs-and-classes <daedalean-structs-and-classes.html>`_, "Yes"
    `daedalean-switch-statement <daedalean-switch-statement.html>`_,
    `daedalean-ternary-operator-must-not-be-used <daedalean-ternary-operator-must-not-be-used.html>`_,
    `daedalean-lambda-return-type <daedalean-lambda-return-type.html>`_, "Yes"

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-protected-must-not-be-used.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-protected-must-not-be-used.cpp
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy %s daedalean-protected-must-not-be-used %t
+
+class A {
+protected:
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: protected modifier must not be used [daedalean-protected-must-not-be-used]
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-structs-and-classes.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-structs-and-classes.cpp
@@ -1,0 +1,35 @@
+// RUN: %check_clang_tidy %s daedalean-structs-and-classes %t
+
+struct S1 {
+  int a;
+};
+
+struct S2 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: Non-POD type must be declared as class [daedalean-structs-and-classes]
+  // CHECK-FIXES: class
+  S2(int a) : b(a) {}
+  int b;
+};
+
+class C1 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: POD type must be declared as struct [daedalean-structs-and-classes]
+  // CHECK-FIXES: struct
+public:
+  const int a;
+};
+
+class C2 {
+public:
+  C2(int a) : b(a) {}
+private:
+  int b;
+};
+
+class C3 {
+public:
+  C3(int) {}
+
+  int a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: All non-const data members of class MUST be private [daedalean-structs-and-classes]
+  // CHECK-FIXES: private:
+};


### PR DESCRIPTION
+ POD types MUST be declared as struct.
+ Non-POD types MUST be declared as class.
+ All non-const data members of class MUST be private.
+ "protected" modifier MUST NOT be used

Relates: T10095