### PR TITLE
Daedalean coding standards for assignment operators

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.cpp
@@ -27,6 +27,10 @@ void AssignmentOperatorsCheck::check(const MatchFinder::MatchResult &Result) {
     return;
   }
 
+  if (MatchedDecl->isStruct()) {
+    return;
+  }
+
   bool hasCopy = false;
   bool hasMove = false;
 

--- a/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.cpp
@@ -1,0 +1,72 @@
+//===--- AssignmentOperatorsCheck.cpp - clang-tidy ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AssignmentOperatorsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void AssignmentOperatorsCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxRecordDecl(hasDefinition()).bind("x"), this);
+}
+
+void AssignmentOperatorsCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<CXXRecordDecl>("x");
+
+  if (MatchedDecl->isAbstract()) {
+    return;
+  }
+
+  bool hasCopy = false;
+  bool hasMove = false;
+
+  for (const auto member: MatchedDecl->methods()) {
+    if (!member->isOverloadedOperator()) {
+      continue;
+    }
+
+    if (member->getOverloadedOperator() != OO_Equal) {
+      continue;
+    }
+
+    if (member->isImplicit()) {
+      continue;
+    }
+
+    const auto argType = member->getParamDecl(0)->getType();
+
+    if (argType.getNonReferenceType().getUnqualifiedType() != MatchedDecl->getTypeForDecl()->getCanonicalTypeUnqualified()) {
+      continue;
+    }
+
+
+    if (argType->isRValueReferenceType()) {
+      hasMove = true;
+    }
+    if (argType->isLValueReferenceType() && argType.getNonReferenceType().isConstQualified()) {
+      hasCopy = true;
+    }
+  }
+
+  if (!hasMove) {
+    diag(MatchedDecl->getLocation(), "Non-abstract class must implement move-assignment operator");
+  }
+
+  if (!hasCopy) {
+    diag(MatchedDecl->getLocation(), "Non-abstract class must implement copy-assignment operator");
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/AssignmentOperatorsCheck.h
@@ -1,0 +1,34 @@
+//===--- AssignmentOperatorsCheck.h - clang-tidy ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_ASSIGNMENTOPERATORSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_ASSIGNMENTOPERATORSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Daedalean coding standards for assignment operators
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-assignment-operators.html
+class AssignmentOperatorsCheck : public ClangTidyCheck {
+public:
+  AssignmentOperatorsCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_ASSIGNMENTOPERATORSCHECK_H

--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_library(clangTidyDaedaleanModule
 
+  AssignmentOperatorsCheck.cpp
   DaedaleanTidyModule.cpp
   CommaOperatorMustNotBeUsedCheck.cpp
   DerivedClassesCheck.cpp

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -9,6 +9,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "AssignmentOperatorsCheck.h"
 #include "CommaOperatorMustNotBeUsedCheck.h"
 #include "DerivedClassesCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
@@ -29,6 +30,8 @@ namespace daedalean {
 class DaedaleanModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<AssignmentOperatorsCheck>(
+        "daedalean-assignment-operators");
     CheckFactories.registerCheck<CommaOperatorMustNotBeUsedCheck>(
         "daedalean-comma-operator-must-not-be-used");
     CheckFactories.registerCheck<DerivedClassesCheck>(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -178,6 +178,9 @@ New checks
   Finds inner loops that have not been unrolled, as well as fully unrolled
   loops with unknown loops bounds or a large number of iterations.
 
+- New :doc:`daedalean-assignment-operators
+  <clang-tidy/checks/daedalean-assignment-operators>` check.
+
 - New :doc:`daedalean-comma-operator-must-not-be-used
   <clang-tidy/checks/daedalean-comma-operator-must-not-be-used>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-assignment-operators.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-assignment-operators.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - daedalean-assignment-operators
+
+daedalean-assignment-operators
+==============================
+
+Daedalean coding standards for assignment operators
+
+Non-abstract classes MUST have copy and move assignment operators explicitly declared as user definded, = default or = delete.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -166,6 +166,7 @@ Clang-Tidy Checks
    `cppcoreguidelines-pro-type-vararg <cppcoreguidelines-pro-type-vararg.html>`_,
    `cppcoreguidelines-slicing <cppcoreguidelines-slicing.html>`_,
    `cppcoreguidelines-special-member-functions <cppcoreguidelines-special-member-functions.html>`_,
+   `daedalean-assignment-operators <daedalean-assignment-operators.html>`_,
    `daedalean-derived-classes <daedalean-derived-classes.html>`_, "Yes"
    `daedalean-comma-operator-must-not-be-used <daedalean-comma-operator-must-not-be-used.html>`_,
    `daedalean-lambda-implicit-capture <daedalean-lambda-implicit-capture.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
@@ -43,3 +43,7 @@ public:
   C7 & operator=(const C7&) = delete;
   C7 & operator=(C7&&) = delete;
 };
+
+struct S {
+
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
@@ -1,0 +1,45 @@
+// RUN: %check_clang_tidy %s daedalean-assignment-operators %t
+
+
+class C1 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+public:
+};
+
+class C2 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+public:
+  C2 & operator=(const C2&);
+};
+
+class C3 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
+public:
+  C3 & operator=(C3&&);
+};
+
+class C4 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+public:
+  C4 & operator=(C4&);
+};
+
+class C5 {
+public:
+  C5 & operator=(const C5&);
+  C5 & operator=(C5&&);
+};
+
+class C6 {
+public:
+  C6 & operator=(const C6&) = default;
+  C6 & operator=(C6&&) = default;
+};
+
+class C7 {
+public:
+  C7 & operator=(const C7&) = delete;
+  C7 & operator=(C7&&) = delete;
+};


### PR DESCRIPTION
Non-abstract classes MUST have copy and move assignment operators explicitly declared as user defined, = default or = delete.

Relates: T10097