### PR TITLE
Daedalean coding standards for floating-point comparison

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -10,6 +10,7 @@ add_clang_library(clangTidyDaedaleanModule
   CommaOperatorMustNotBeUsedCheck.cpp
   DerivedClassesCheck.cpp
   EnumClassCheck.cpp
+  FloatingPointComparisonCheck.cpp
   LambdaImplicitCaptureCheck.cpp
   StructsAndClassesCheck.cpp
   ProtectedMustNotBeUsedCheck.cpp

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -13,6 +13,7 @@
 #include "CommaOperatorMustNotBeUsedCheck.h"
 #include "DerivedClassesCheck.h"
 #include "EnumClassCheck.h"
+#include "FloatingPointComparisonCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
 #include "ProtectedMustNotBeUsedCheck.h"
 #include "StructsAndClassesCheck.h"
@@ -39,6 +40,8 @@ public:
         "daedalean-derived-classes");
     CheckFactories.registerCheck<EnumClassCheck>(
         "daedalean-enum-class");
+    CheckFactories.registerCheck<FloatingPointComparisonCheck>(
+        "daedalean-floating-point-comparison");
     CheckFactories.registerCheck<LambdaImplicitCaptureCheck>(
         "daedalean-lambda-implicit-capture");
     CheckFactories.registerCheck<ProtectedMustNotBeUsedCheck>(

--- a/clang-tools-extra/clang-tidy/daedalean/FloatingPointComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/FloatingPointComparisonCheck.cpp
@@ -1,0 +1,38 @@
+//===--- FloatingPointComparisonCheck.cpp - clang-tidy --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "FloatingPointComparisonCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void FloatingPointComparisonCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(binaryOperator().bind("x"), this);
+}
+
+void FloatingPointComparisonCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<BinaryOperator>("x");
+  if (!MatchedDecl->isEqualityOp()) {
+    return;
+  }
+
+  if(!MatchedDecl->getLHS()->getType()->isFloatingType() && !MatchedDecl->getRHS()->getType()->isFloatingType()) {
+    return;
+  }
+
+  diag(MatchedDecl->getOperatorLoc(), "Floating point expressions MUST NOT be checked for equality or inequality");
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/FloatingPointComparisonCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/FloatingPointComparisonCheck.h
@@ -1,0 +1,34 @@
+//===--- FloatingPointComparisonCheck.h - clang-tidy ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FLOATINGPOINTCOMPARISONCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FLOATINGPOINTCOMPARISONCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Floating point expressions MUST NOT be checked for equality or inequality.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-floating-point-comparison.html
+class FloatingPointComparisonCheck : public ClangTidyCheck {
+public:
+  FloatingPointComparisonCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FLOATINGPOINTCOMPARISONCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -221,6 +221,11 @@ New checks
 - New :doc:`daedalean-enum-class
   <clang-tidy/checks/daedalean-enum-class>` check.
 
+- New :doc:`daedalean-floating-point-comparison
+  <clang-tidy/checks/daedalean-floating-point-comparison>` check.
+
+  FIXME: add release notes.
+
 - New :doc:`daedalean-lambda-implicit-capture
   <clang-tidy/checks/daedalean-lambda-implicit-capture>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-floating-point-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-floating-point-comparison.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - daedalean-floating-point-comparison
+
+daedalean-floating-point-comparison
+===================================
+
+Daedalean coding standards for floating-point comparison
+
+Floating point expressions MUST NOT be checked for equality or inequality

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -169,6 +169,7 @@ Clang-Tidy Checks
    `daedalean-assignment-operators <daedalean-assignment-operators.html>`_,
    `daedalean-derived-classes <daedalean-derived-classes.html>`_, "Yes"
    `daedalean-enum-class <daedalean-enum-class.html>`_, "Yes"
+   `daedalean-floating-point-comparison <daedalean-floating-point-comparison.html>`_,
    `daedalean-lambda-implicit-capture <daedalean-lambda-implicit-capture.html>`_,
    `daedalean-protected-must-not-be-used <daedalean-protected-must-not-be-used.html>`_,
    `daedalean-structs-and-classes <daedalean-structs-and-classes.html>`_, "Yes"

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-floating-point-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-floating-point-comparison.cpp
@@ -1,0 +1,43 @@
+// RUN: %check_clang_tidy %s daedalean-floating-point-comparison %t
+
+float f1 = 1.0f;
+float f2 = 1.0f;
+double d1 = 2.0f;
+double d2 = 2.0f;
+int i1 = 1;
+int i2 = 1;
+
+bool r1 = f1 == f2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r2 = f1 != f2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r3 = d1 == d2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r4 = d1 != d2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r5 = d1 == f2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r6 = d1 != f2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r7 = d1 == i2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r8 = d1 != i2;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r9 = i1 == i2;
+bool r10 = i1 != i2;
+bool r11 = 1 == 2.0;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+bool r12 = 1 != 2.0;
+// CHECK-MESSAGES: :[[@LINE-1]]:14: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+
+
+template<typename T>
+bool foo(const T a, const T b) {
+  return a == b;
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: Floating point expressions MUST NOT be checked for equality or inequality [daedalean-floating-point-comparison]
+}
+
+bool r31 = foo(f1, f2);
+
+
+


### PR DESCRIPTION
Floating point expressions MUST NOT be checked for equality or inequality

Relates: T10090