### PR TITLE
Daedalen coding standards: Friend declarations MUST not be used

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangTidyDaedaleanModule
   DerivedClassesCheck.cpp
   EnumClassCheck.cpp
   FloatingPointComparisonCheck.cpp
+  FriendDeclarationsCheck.cpp
   IncludeOrderCheck.cpp
   LambdaImplicitCaptureCheck.cpp
   PreprocessingDirectivesCheck.cpp

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -15,6 +15,7 @@
 #include "DerivedClassesCheck.h"
 #include "EnumClassCheck.h"
 #include "FloatingPointComparisonCheck.h"
+#include "FriendDeclarationsCheck.h"
 #include "IncludeOrderCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
 #include "PreprocessingDirectivesCheck.h"
@@ -47,6 +48,8 @@ public:
         "daedalean-enum-class");
     CheckFactories.registerCheck<FloatingPointComparisonCheck>(
         "daedalean-floating-point-comparison");
+    CheckFactories.registerCheck<FriendDeclarationsCheck>(
+        "daedalean-friend-declarations");
     CheckFactories.registerCheck<IncludeOrderCheck>(
         "daedalean-include-order");
     CheckFactories.registerCheck<LambdaImplicitCaptureCheck>(

--- a/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.cpp
@@ -1,0 +1,62 @@
+//===--- FriendDeclarationsCheck.cpp - clang-tidy -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "FriendDeclarationsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void FriendDeclarationsCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(friendDecl().bind("x"), this);
+}
+
+void FriendDeclarationsCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<FriendDecl>("x");
+
+  const auto decl = MatchedDecl->getFriendDecl();
+
+  if (MatchedDecl->isFunctionOrFunctionTemplate() || true) {
+    if (const auto method = llvm::dyn_cast_or_null<FunctionDecl>(decl); method) {
+        if (method->isOverloadedOperator()) {
+          if (method->getNumParams() == 2) {
+            if (const auto cls = llvm::dyn_cast_or_null<CXXRecordDecl>(MatchedDecl->getLexicalDeclContext())) {
+              const auto type = cls->getTypeForDecl()->getCanonicalTypeUnqualified();
+
+              if (type == method->getParamDecl(1)->getType().getNonReferenceType()->getCanonicalTypeUnqualified()) {
+                if (type != method->getParamDecl(0)->getType().getNonReferenceType()->getCanonicalTypeUnqualified()) {
+                  return;
+                }
+              }
+            }
+          }
+        }
+    }
+  }
+
+  if (MatchedDecl->isTemplated()) {
+    const auto ctx  = MatchedDecl->getLexicalDeclContext();
+    if (const auto cls = llvm::dyn_cast_or_null<const CXXRecordDecl>(ctx); cls && cls->isTemplated()) {
+      if (const auto friendCls =llvm::dyn_cast_or_null<ClassTemplateDecl>(decl); friendCls) {
+        if (cls->getQualifiedNameAsString() == friendCls->getQualifiedNameAsString()) {
+          return;
+        }
+      }
+    }
+  }
+
+  diag(MatchedDecl->getLocation(), "Friend declaration must not be used");
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.cpp
@@ -25,29 +25,42 @@ void FriendDeclarationsCheck::check(const MatchFinder::MatchResult &Result) {
 
   const auto decl = MatchedDecl->getFriendDecl();
 
-  if (MatchedDecl->isFunctionOrFunctionTemplate() || true) {
-    if (const auto method = llvm::dyn_cast_or_null<FunctionDecl>(decl); method) {
-        if (method->isOverloadedOperator()) {
-          if (method->getNumParams() == 2) {
-            if (const auto cls = llvm::dyn_cast_or_null<CXXRecordDecl>(MatchedDecl->getLexicalDeclContext())) {
-              const auto type = cls->getTypeForDecl()->getCanonicalTypeUnqualified();
+  if (MatchedDecl->isFunctionOrFunctionTemplate()) {
+    if (const auto method = llvm::dyn_cast_or_null<FunctionDecl>(decl);
+        method) {
+      if (method->isOverloadedOperator()) {
+        if (method->getNumParams() == 2) {
+          if (const auto cls = llvm::dyn_cast_or_null<CXXRecordDecl>(
+                  MatchedDecl->getLexicalDeclContext())) {
+            const auto type =
+                cls->getTypeForDecl()->getCanonicalTypeUnqualified();
 
-              if (type == method->getParamDecl(1)->getType().getNonReferenceType()->getCanonicalTypeUnqualified()) {
-                if (type != method->getParamDecl(0)->getType().getNonReferenceType()->getCanonicalTypeUnqualified()) {
-                  return;
-                }
+            if (type == method->getParamDecl(1)
+                            ->getType()
+                            .getNonReferenceType()
+                            ->getCanonicalTypeUnqualified()) {
+              if (type != method->getParamDecl(0)
+                              ->getType()
+                              .getNonReferenceType()
+                              ->getCanonicalTypeUnqualified()) {
+                return;
               }
             }
           }
         }
+      }
     }
   }
 
   if (MatchedDecl->isTemplated()) {
-    const auto ctx  = MatchedDecl->getLexicalDeclContext();
-    if (const auto cls = llvm::dyn_cast_or_null<const CXXRecordDecl>(ctx); cls && cls->isTemplated()) {
-      if (const auto friendCls =llvm::dyn_cast_or_null<ClassTemplateDecl>(decl); friendCls) {
-        if (cls->getQualifiedNameAsString() == friendCls->getQualifiedNameAsString()) {
+    const auto ctx = MatchedDecl->getLexicalDeclContext();
+    if (const auto cls = llvm::dyn_cast_or_null<const CXXRecordDecl>(ctx);
+        cls && cls->isTemplated()) {
+      if (const auto friendCls =
+              llvm::dyn_cast_or_null<ClassTemplateDecl>(decl);
+          friendCls) {
+        if (cls->getQualifiedNameAsString() ==
+            friendCls->getQualifiedNameAsString()) {
           return;
         }
       }

--- a/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/FriendDeclarationsCheck.h
@@ -1,0 +1,34 @@
+//===--- FriendDeclarationsCheck.h - clang-tidy -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FRIENDDECLARATIONSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FRIENDDECLARATIONSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Daedalen coding standards: Friend declarations MUST not be used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-friend-declarations.html
+class FriendDeclarationsCheck : public ClangTidyCheck {
+public:
+  FriendDeclarationsCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_FRIENDDECLARATIONSCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -229,6 +229,11 @@ New checks
 
   FIXME: add release notes.
 
+- New :doc:`daedalean-friend-declarations
+  <clang-tidy/checks/daedalean-friend-declarations>` check.
+
+  FIXME: add release notes.
+
 - New :doc:`daedalean-include-order
   <clang-tidy/checks/daedalean-include-order>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-friend-declarations.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-friend-declarations.rst
@@ -1,0 +1,10 @@
+.. title:: clang-tidy - daedalean-friend-declarations
+
+daedalean-friend-declarations
+=============================
+
+Daedalen coding standards: Friend declarations MUST not be used
+
+Exceptions:
+1. Overload operators with first argument of different type
+2. Friend declaration for different instantiations of the same template

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -172,11 +172,12 @@ Clang-Tidy Checks
    `daedalean-derived-classes <daedalean-derived-classes.html>`_, "Yes"
    `daedalean-enum-class <daedalean-enum-class.html>`_, "Yes"
    `daedalean-floating-point-comparison <daedalean-floating-point-comparison.html>`_,
+   `daedalean-friend-declarations <daedalean-friend-declarations.html>`_,
    `daedalean-include-order <daedalean-include-order.html>`_, "Yes"
    `daedalean-lambda-implicit-capture <daedalean-lambda-implicit-capture.html>`_,
    `daedalean-lambda-return-type <daedalean-lambda-return-type.html>`_, "Yes"
    `daedalean-operator-overloading <daedalean-operator-overloading.html>`_,
-   `daedalean-preprocessing-directives <daedalean-preprocessing-directives.html>`_, "Yes"
+   `daedalean-preprocessing-directives <daedalean-preprocessing-directives.html>`_,
    `daedalean-protected-must-not-be-used <daedalean-protected-must-not-be-used.html>`_,
    `daedalean-structs-and-classes <daedalean-structs-and-classes.html>`_, "Yes"
    `daedalean-switch-statement <daedalean-switch-statement.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-friend-declarations.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-friend-declarations.cpp
@@ -1,0 +1,20 @@
+// RUN: %check_clang_tidy %s daedalean-friend-declarations %t
+
+class S {};
+
+class A {
+  friend class B;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: Friend declaration must not be used [daedalean-friend-declarations]
+  friend void foo();
+  // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: Friend declaration must not be used [daedalean-friend-declarations]
+  friend S& operator << (S&, const A&);
+};
+
+
+template<typename T>
+class C {
+
+  template<typename U>
+  friend class C;
+};
+


### PR DESCRIPTION
Exceptions:
1. Overload operators with first argument of different type
2. Friend declaration for different instantiations of the same template

Relates: T10096