### PR TITLE
Daedalean coding standards for local methods and types

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -15,6 +15,7 @@ add_clang_library(clangTidyDaedaleanModule
   FriendDeclarationsCheck.cpp
   IncludeOrderCheck.cpp
   LambdaImplicitCaptureCheck.cpp
+  LocalMethodsAndTypesCheck.cpp
   PreprocessingDirectivesCheck.cpp
   StructsAndClassesCheck.cpp
   ProtectedMustNotBeUsedCheck.cpp

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -18,6 +18,7 @@
 #include "FriendDeclarationsCheck.h"
 #include "IncludeOrderCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
+#include "LocalMethodsAndTypesCheck.h"
 #include "PreprocessingDirectivesCheck.h"
 #include "ProtectedMustNotBeUsedCheck.h"
 #include "StructsAndClassesCheck.h"
@@ -54,6 +55,8 @@ public:
         "daedalean-include-order");
     CheckFactories.registerCheck<LambdaImplicitCaptureCheck>(
         "daedalean-lambda-implicit-capture");
+    CheckFactories.registerCheck<LocalMethodsAndTypesCheck>(
+        "daedalean-local-methods-and-types");
     CheckFactories.registerCheck<PreprocessingDirectivesCheck>(
         "daedalean-preprocessing-directives");
     CheckFactories.registerCheck<ProtectedMustNotBeUsedCheck>(

--- a/clang-tools-extra/clang-tidy/daedalean/LocalMethodsAndTypesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/LocalMethodsAndTypesCheck.cpp
@@ -1,0 +1,76 @@
+//===--- LocalMethodsAndTypesCheck.cpp - clang-tidy -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LocalMethodsAndTypesCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+namespace {
+
+bool isSpellingLocInHeaderFile(SourceLocation Loc, SourceManager &SM) {
+  SourceLocation SpellingLoc = SM.getSpellingLoc(Loc);
+  const auto fileName = SM.getFilename(SpellingLoc);
+
+  return fileName.endswith(".h") || fileName.endswith("hh");
+}
+
+bool isInAnonymousNamespace(const DeclContext *decl) {
+  if (!decl) {
+    return false;
+  }
+
+  if (const auto ns = llvm::dyn_cast_or_null<NamespaceDecl>(decl); ns) {
+    if (ns->isAnonymousNamespace()) {
+      return true;
+    }
+  }
+
+  return isInAnonymousNamespace(decl->getParent());
+}
+
+} // namespace
+
+void LocalMethodsAndTypesCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(functionDecl().bind("x"), this);
+  Finder->addMatcher(recordDecl().bind("x"), this);
+}
+
+void LocalMethodsAndTypesCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<NamedDecl>("x");
+
+  if (!MatchedDecl->isFirstDecl()) {
+    return;
+  }
+
+  if (isSpellingLocInHeaderFile(MatchedDecl->getBeginLoc(),
+                                *Result.SourceManager)) {
+    return;
+  }
+
+  if (isInAnonymousNamespace(MatchedDecl->getDeclContext())) {
+    return;
+  }
+
+  if (MatchedDecl->isFunctionOrFunctionTemplate()) {
+    diag(MatchedDecl->getLocation(),
+         "Local function must be declared in anonymous namespace");
+  } else {
+    diag(MatchedDecl->getLocation(),
+         "Local type must be declared in anonymous namespace");
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/LocalMethodsAndTypesCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/LocalMethodsAndTypesCheck.h
@@ -1,0 +1,34 @@
+//===--- LocalMethodsAndTypesCheck.h - clang-tidy ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_LOCALMETHODSANDTYPESCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_LOCALMETHODSANDTYPESCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// All types, methods and constants used only inside a single translation unit MUST be placed in anonymous namespace.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-local-methods-and-types.html
+class LocalMethodsAndTypesCheck : public ClangTidyCheck {
+public:
+  LocalMethodsAndTypesCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_LOCALMETHODSANDTYPESCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -244,6 +244,9 @@ New checks
 
   FIXME: add release notes.
 
+- New :doc:`daedalean-local-methods-and-types
+  <clang-tidy/checks/daedalean-local-methods-and-types>` check.
+
 - New :doc:`daedalean-preprocessing-directives
   <clang-tidy/checks/daedalean-preprocessing-directives>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-comma-operator-must-not-be-used.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-comma-operator-must-not-be-used.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - daedalean-comma-operator-must-not-be-used
+
+daedalean-comma-operator-must-not-be-used
+=================================
+
+Daedalean coding standards for comma operator
+
+Comma operator MUST NOT be used

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-local-methods-and-types.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-local-methods-and-types.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - daedalean-local-methods-and-types
+
+daedalean-local-methods-and-types
+=================================
+
+Daedalean coding standards for local methods and types
+
+All types, methods and constants used only inside a single translation unit MUST be placed in anonymous namespace.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -176,6 +176,7 @@ Clang-Tidy Checks
    `daedalean-include-order <daedalean-include-order.html>`_, "Yes"
    `daedalean-lambda-implicit-capture <daedalean-lambda-implicit-capture.html>`_,
    `daedalean-lambda-return-type <daedalean-lambda-return-type.html>`_, "Yes"
+   `daedalean-local-methods-and-types <daedalean-local-methods-and-types.html>`_,
    `daedalean-operator-overloading <daedalean-operator-overloading.html>`_,
    `daedalean-preprocessing-directives <daedalean-preprocessing-directives.html>`_,
    `daedalean-protected-must-not-be-used <daedalean-protected-must-not-be-used.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-local-methods-and-types.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-local-methods-and-types.cpp
@@ -1,0 +1,30 @@
+// RUN: %check_clang_tidy %s daedalean-local-methods-and-types %t -- -- -I`pwd`/../test/clang-tidy/checkers
+
+#include "daedalean-local-methods-and-types.hh"
+
+void foo1();
+
+void foo2() {}
+
+void bar1();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Local function must be declared in anonymous namespace [daedalean-local-methods-and-types]
+
+void bar2() {}
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Local function must be declared in anonymous namespace [daedalean-local-methods-and-types]
+
+struct S2 {};
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: Local type must be declared in anonymous namespace [daedalean-local-methods-and-types]
+
+namespace {
+
+void baz();
+
+void baz() {}
+
+struct S1;
+
+struct S1{
+  void foo();
+};
+
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-local-methods-and-types.hh
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-local-methods-and-types.hh
@@ -1,0 +1,8 @@
+// RUN: %check_clang_tidy %s daedalean-local-methods-and-types %t
+
+void foo1();
+void foo2();
+
+struct S {
+
+};


### PR DESCRIPTION
All types, methods and constants used only inside a single translation unit MUST be placed in anonymous namespace.

Relates: T10103