### PR TITLE
Fix daedalean-assignment-operators

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/DerivedClassesCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/DerivedClassesCheck.h
@@ -12,6 +12,7 @@
 #include "../ClangTidyCheck.h"
 
 #include <set>
+#include <unordered_map>
 
 namespace clang {
 namespace tidy {

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
@@ -1,49 +1,50 @@
 // RUN: %check_clang_tidy %s daedalean-assignment-operators %t
 
-
 class C1 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
-  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C1' must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class 'C1' must implement move-assignment operator [daedalean-assignment-operators]
 public:
 };
 
 class C2 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C2' must implement move-assignment operator [daedalean-assignment-operators]
 public:
-  C2 & operator=(const C2&);
+  C2 &operator=(const C2 &);
 };
 
 class C3 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C3' must implement copy-assignment operator [daedalean-assignment-operators]
 public:
-  C3 & operator=(C3&&);
+  C3 &operator=(C3 &&);
 };
 
 class C4 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
-  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C4' must implement move-assignment operator [daedalean-assignment-operators]
 public:
-  C4 & operator=(C4&);
+  C4 &operator=(C4 &);
 };
 
 class C5 {
 public:
-  C5 & operator=(const C5&);
-  C5 & operator=(C5&&);
+  C5 &operator=(const C5 &);
+  C5 &operator=(C5 &&);
 };
 
 class C6 {
 public:
-  C6 & operator=(const C6&) = default;
-  C6 & operator=(C6&&) = default;
+  C6 &operator=(const C6 &) = default;
+  C6 &operator=(C6 &&) = default;
 };
 
 class C7 {
 public:
-  C7 & operator=(const C7&) = delete;
-  C7 & operator=(C7&&) = delete;
+  C7 &operator=(const C7 &) = delete;
+  C7 &operator=(C7 &&) = delete;
 };
 
 struct S {
-
 };
+
+class ForwardDeclaredClass;
+
+struct ForwardDeclaredStruct;


### PR DESCRIPTION
isBeingDefined returns false even for class definitions, making this
check not work at all and is not needed as evidenced by the forward declarations in the test. 
Also, this check did not consider copy and move assignment operators in all their forms, so moving to
hasUserDeclaredCopyAssignment and hasUserDeclaredMoveAssignment should
be a preferred and more standard way to detect user declared move
assignment and ccopy assignment operators. These checks also work when
the definitions are deleted.

Tested with:
./build/bin/llvm-lit -v clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp