### PR TITLE
Fix daedalean-friend-declarations check

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/DerivedClassesCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/DerivedClassesCheck.h
@@ -12,6 +12,7 @@
 #include "../ClangTidyCheck.h"
 
 #include <set>
+#include <unordered_map>
 
 namespace clang {
 namespace tidy {

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-assignment-operators.cpp
@@ -1,49 +1,50 @@
 // RUN: %check_clang_tidy %s daedalean-assignment-operators %t
 
-
 class C1 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
-  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C1' must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class 'C1' must implement move-assignment operator [daedalean-assignment-operators]
 public:
 };
 
 class C2 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C2' must implement move-assignment operator [daedalean-assignment-operators]
 public:
-  C2 & operator=(const C2&);
+  C2 &operator=(const C2 &);
 };
 
 class C3 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C3' must implement copy-assignment operator [daedalean-assignment-operators]
 public:
-  C3 & operator=(C3&&);
+  C3 &operator=(C3 &&);
 };
 
 class C4 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class must implement copy-assignment operator [daedalean-assignment-operators]
-  // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Non-abstract class must implement move-assignment operator [daedalean-assignment-operators]
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Non-abstract class 'C4' must implement move-assignment operator [daedalean-assignment-operators]
 public:
-  C4 & operator=(C4&);
+  C4 &operator=(C4 &);
 };
 
 class C5 {
 public:
-  C5 & operator=(const C5&);
-  C5 & operator=(C5&&);
+  C5 &operator=(const C5 &);
+  C5 &operator=(C5 &&);
 };
 
 class C6 {
 public:
-  C6 & operator=(const C6&) = default;
-  C6 & operator=(C6&&) = default;
+  C6 &operator=(const C6 &) = default;
+  C6 &operator=(C6 &&) = default;
 };
 
 class C7 {
 public:
-  C7 & operator=(const C7&) = delete;
-  C7 & operator=(C7&&) = delete;
+  C7 &operator=(const C7 &) = delete;
+  C7 &operator=(C7 &&) = delete;
 };
 
 struct S {
-
 };
+
+class ForwardDeclaredClass;
+
+struct ForwardDeclaredStruct;

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-friend-declarations.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-friend-declarations.cpp
@@ -1,20 +1,21 @@
 // RUN: %check_clang_tidy %s daedalean-friend-declarations %t
-#if 0
+
 class S {};
+
+class B {};
 
 class A {
   friend class B;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: Friend declaration must not be used [daedalean-friend-declarations]
   friend void foo();
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: Friend declaration must not be used [daedalean-friend-declarations]
-  friend S& operator << (S&, const A&);
+  friend S &operator<<(S &, const A &);
 };
 
-#endif
-template<typename T>
+template <typename T>
 class C {
 
-  template<typename U>
+  template <typename U>
   friend class C;
 };
 


### PR DESCRIPTION
Use the right argument to check if the friend is an overloaded
operator. Remove `#if 0` that prevented the test from passing.

Tested with:
./build/bin/llvm-lit -v clang-tools-extra/test/clang-tidy/checkers/daedalean-friend-declarations.cpp