### PR TITLE
Add  daedalean-use-nodiscard for CS.R.5

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -29,6 +29,7 @@ add_clang_library(clangTidyDaedaleanModule
   UnionsMustNotBeUsedCheck.cpp
   VarargFunctionsMustNotBeUsedCheck.cpp
   UseNoexceptCheck.cpp
+  UseNodiscardCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -30,6 +30,7 @@
 #include "TernaryOperatorMustNotBeUsedCheck.h"
 #include "TypeConversionsCheck.h"
 #include "UnionsMustNotBeUsedCheck.h"
+#include "UseNodiscardCheck.h"
 #include "UseNoexceptCheck.h"
 #include "VarargFunctionsMustNotBeUsedCheck.h"
 
@@ -90,6 +91,7 @@ public:
     CheckFactories.registerCheck<UseNoexceptCheck>("daedalean-use-noexcept");
     CheckFactories.registerCheck<VarargFunctionsMustNotBeUsedCheck>(
         "daedalean-vararg-functions-must-not-be-used");
+    CheckFactories.registerCheck<UseNodiscardCheck>("daedalean-use-nodiscard");
   }
 };
 

--- a/clang-tools-extra/clang-tidy/daedalean/UseNodiscardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/UseNodiscardCheck.cpp
@@ -1,0 +1,128 @@
+//===--- UseNodiscardCheck.cpp - clang-tidy -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseNodiscardCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "daedalean-use-nodiscard"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+namespace {
+AST_MATCHER(CXXMethodDecl, isOverloadedAssignmentOperator) {
+  // Don't put ``[[nodiscard]]`` in front of assignment operators that return a
+  // reference.
+  return Node.isOverloadedOperator() &&
+         (Node.getOverloadedOperator() == OverloadedOperatorKind::OO_Equal) &&
+         Node.getReturnType()->isReferenceType();
+}
+
+AST_MATCHER(CXXMethodDecl, isLambda) {
+  const RecordDecl *Parent = Node.getParent();
+  return Parent && Parent->isLambda();
+}
+
+AST_MATCHER(FunctionDecl, isNotMethod) {
+  // A function which is not a method
+  return !llvm::isa<CXXMethodDecl>(Node);
+}
+
+AST_MATCHER(FunctionDecl, isDefinitionOrInline) {
+  // A function definition, with optional inline but not the declaration.
+  return !(Node.isThisDeclarationADefinition() && Node.isOutOfLine());
+}
+
+AST_MATCHER(CXXMethodDecl, isOverloadedPredecrementOperator) {
+  // Don't put ``[[nodiscard]]`` in front of predecrement operators that return
+  // a reference.
+  return Node.isOverloadedOperator() &&
+         (Node.getOverloadedOperator() ==
+          OverloadedOperatorKind::OO_MinusMinus) &&
+         Node.getReturnType()->isReferenceType() &&
+         (Node.parameters().size() == 0);
+}
+AST_MATCHER(CXXMethodDecl, isOverloadedPreincrementOperator) {
+  // Don't put ``[[nodiscard]]`` in front of preincrement operators that return
+  // a reference.
+  return Node.isOverloadedOperator() &&
+         (Node.getOverloadedOperator() ==
+          OverloadedOperatorKind::OO_PlusPlus) &&
+         Node.getReturnType()->isReferenceType() &&
+         (Node.parameters().size() == 0);
+}
+} // namespace
+
+UseNodiscardCheck::UseNodiscardCheck(StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void UseNodiscardCheck::registerMatchers(MatchFinder *Finder) {
+  // Find all non-void methods which have not already been marked to
+  // warn on unused result.
+  //
+  // Lambdas are excluded because c++20 does not have a way to mark the.
+  // operator() as nodiscard in lambdas, so there is no point in warning.
+  Finder->addMatcher(
+      cxxMethodDecl(
+          allOf(isDefinitionOrInline(),
+                unless(anyOf(isLambda(), returns(voidType()), isNoReturn(),
+                             isOverloadedAssignmentOperator(),
+                             isOverloadedPreincrementOperator(),
+                             isOverloadedPredecrementOperator()))))
+          .bind("no_discard"),
+      this);
+  Finder->addMatcher(
+      functionDecl(allOf(isNotMethod(), isDefinitionOrInline(),
+                         unless(anyOf(returns(voidType()), isNoReturn()))))
+          .bind("no_discard_func"),
+      this);
+}
+
+void UseNodiscardCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<FunctionDecl>("no_discard");
+  if (MatchedDecl == nullptr) {
+    MatchedDecl = Result.Nodes.getNodeAs<FunctionDecl>("no_discard_func");
+  }
+
+  for (const auto *Attr : MatchedDecl->attrs()) {
+    StringRef spelling{Attr->getSpelling()};
+    LLVM_DEBUG(llvm::dbgs() << "spelling: " << spelling << '\n');
+    if (spelling == "nodiscard") {
+      return;
+    }
+  }
+
+  // Don't make replacements if the location is invalid or in a macro.
+  SourceLocation Loc = MatchedDecl->getLocation();
+  if (Loc.isInvalid() || Loc.isMacroID())
+    return;
+
+  SourceLocation RetLoc = MatchedDecl->getInnerLocStart();
+
+  auto Diag = diag(RetLoc, "function %0 should be marked [[nodiscard]]")
+              << MatchedDecl;
+
+  Diag << FixItHint::CreateInsertion(RetLoc, "[[nodiscard]] ");
+}
+
+bool UseNodiscardCheck::isLanguageVersionSupported(
+    const LangOptions &LangOpts) const {
+  // If we use ``[[nodiscard]]`` attribute, we require at least C++17.
+  return LangOpts.CPlusPlus17;
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/UseNodiscardCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/UseNodiscardCheck.h
@@ -1,0 +1,46 @@
+//===--- UseNodiscardCheck.h - clang-tidy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENODISCARDCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENODISCARDCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Add ``[[nodiscard]]`` to non-void functions with no
+/// arguments or pass-by-value or pass by const-reference arguments.
+/// \code
+///    bool empty() const;
+///    bool empty(const Bar &) const;
+///    bool empty(int bar) const;
+/// \endcode
+/// Is converted to:
+/// \code
+///    [[nodiscard]] bool empty() const;
+///    [[nodiscard]] bool empty(const Bar &) const;
+///    [[nodiscard]] bool empty(int bar) const;
+/// \endcode
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-use-nodiscard.html
+class UseNodiscardCheck : public ClangTidyCheck {
+public:
+  UseNodiscardCheck(StringRef Name, ClangTidyContext *Context);
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override;
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENODISCARDCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -277,12 +277,20 @@ New checks
 - New :doc:`daedalean-unions-must-not-be-used
   <clang-tidy/checks/daedalean-unions-must-not-be-used>` check.
 
-  Finds function/method declarations and makes sure they have a noexcept specifier or warns the user.
+  Warns if unions are used.
+
+- New :doc:`daedalean-use-nodiscard
+  <clang-tidy/checks/daedalean-use-nodiscard>` check.
+
+  Finds all functions and methods returning non-void and warns that they should be marked nodiscard.
+  Exceptions:
+   - Preincrement and predecrement operators that return references.
+   - Assignment operators that return references.
 
 - New :doc:`daedalean-use-noexcept
   <clang-tidy/checks/daedalean-use-noexcept>` check.
 
-  FIXME: add release notes.
+  Finds function/method declarations and makes sure they have a noexcept specifier or warns the user.
 
 - New :doc:`daedalean-vararg-functions-must-not-be-used
   <clang-tidy/checks/daedalean-vararg-functions-must-not-be-used>` check.

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-use-nodiscard.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-use-nodiscard.rst
@@ -1,0 +1,71 @@
+.. title:: clang-tidy - daedalean-use-nodiscard
+
+daedalean-use-nodiscard
+=======================
+
+Adds ``[[nodiscard]]`` attributes (introduced in C++17) to member functions in
+order to highlight at compile time which return values should not be ignored.
+
+Member functions need to satisfy the following conditions to be considered by
+this check:
+
+ - no ``[[nodiscard]]``, ``[[noreturn]]``,
+   ``__attribute__((warn_unused_result))``,
+   ``[[clang::warn_unused_result]]`` nor ``[[gcc::warn_unused_result]]``
+   attribute,
+ - non-void return type,
+ - no Lambdas,
+ - Reference returned from assignment operators may be discarded
+ - Reference returned from prefix increment and decrement may be discarded
+
+Example
+-------
+
+.. code-block:: c++
+
+    bool empty() const;
+    bool empty(int i) const;
+
+transforms to:
+
+.. code-block:: c++
+
+    [[nodiscard]] bool empty() const;
+    [[nodiscard]] bool empty(int i) const;
+
+Options
+-------
+
+.. option:: ReplacementString
+
+    Specifies a macro to use instead of ``[[nodiscard]]``. This is useful when
+    maintaining source code that needs to compile with a pre-C++17 compiler.
+
+Example
+^^^^^^^
+
+.. code-block:: c++
+
+    bool empty() const;
+    bool empty(int i) const;
+
+transforms to:
+
+.. code-block:: c++
+
+    NO_DISCARD bool empty() const;
+    NO_DISCARD bool empty(int i) const;
+
+if the :option:`ReplacementString` option is set to `NO_DISCARD`.
+
+.. note::
+
+    If the :option:`ReplacementString` is not a C++ attribute, but instead a
+    macro, then that macro must be defined in scope or the fix-it will not be
+    applied.
+
+.. note::
+
+    For alternative ``__attribute__`` syntax options to mark functions as
+    ``[[nodiscard]]`` in non-c++17 source code.
+    See https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -193,6 +193,7 @@ Clang-Tidy Checks
    `daedalean-unions-must-not-be-used <daedalean-unions-must-not-be-used.html>`_,
    `daedalean-use-noexcept <daedalean-use-noexcept.html>`_,
    `daedalean-vararg-functions-must-not-be-used <daedalean-vararg-functions-must-not-be-used.html>`_,
+   `daedalean-use-nodiscard <daedalean-use-nodiscard.html>`_, "Yes"
    `darwin-avoid-spinlock <darwin-avoid-spinlock.html>`_,
    `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_, "Yes"
    `fuchsia-default-arguments-calls <fuchsia-default-arguments-calls.html>`_,
@@ -352,7 +353,6 @@ Clang-Tidy Checks
    `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
    `readability-use-anyofallof <readability-use-anyofallof.html>`_,
    `zircon-temporary-objects <zircon-temporary-objects.html>`_,
-
 
 .. csv-table:: Aliases..
    :header: "Name", "Redirect", "Offers fixes"

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-use-nodiscard.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-use-nodiscard.cpp
@@ -1,0 +1,354 @@
+// RUN: %check_clang_tidy -std c++20 %s daedalean-use-nodiscard %t
+
+namespace std {
+template <class>
+class function;
+class string {};
+} // namespace std
+
+namespace boost {
+template <class>
+class function;
+}
+
+typedef unsigned my_unsigned;
+typedef unsigned &my_unsigned_reference;
+typedef const unsigned &my_unsigned_const_reference;
+
+struct [[nodiscard]] NoDiscardStruct {};
+
+class Foo {
+public:
+  using size_type = unsigned;
+
+  bool f1() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f1' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f1() const;
+
+  bool f2(int) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f2' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f2(int) const;
+
+  bool f3(const int &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f3' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f3(const int &) const;
+
+  bool f4(void) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f4' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f4(void) const;
+
+  void f5() const;
+
+  bool f6();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f6' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f6();
+
+  bool f7(int &);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f7' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f7(int &);
+
+  bool f8(int &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f8' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f8(int &) const;
+
+  bool f9(int *) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f9' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f9(int *) const;
+
+  bool f10(const int &, int &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f10' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f10(const int &, int &) const;
+
+  [[nodiscard]] bool f12() const;
+
+  __attribute__((warn_unused_result)) bool f13() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f13' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+
+  [[nodiscard]] bool f11() const;
+
+  [[clang::warn_unused_result]] bool f11a() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: function 'f11a' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+
+  [[gnu::warn_unused_result]] bool f11b() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: function 'f11b' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+
+  bool _f20() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function '_f20' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool _f20() const;
+
+  [[noreturn]] bool f21() const;
+
+  ~Foo();
+
+  // Reference returned from prefix increment and decrement MAY be discarded
+  Foo &operator++() const;
+
+  // Reference returned from prefix increment and decrement MAY be discarded
+  Foo &operator--() const;
+
+  Foo operator--(int) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator--' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] Foo operator--(int) const;
+
+  Foo &operator++(int) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator++' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] Foo &operator++(int) const;
+
+  bool operator+=(int) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator+=' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool operator+=(int) const;
+
+  // extra keywords (virtual,inline,const) on return type
+
+  virtual bool f14() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f14' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] virtual bool f14() const;
+
+  const bool f15() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f15' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] const bool f15() const;
+
+  inline const bool f16() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f16' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] inline const bool f16() const;
+
+  inline const std::string &f45() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f45' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] inline const std::string &f45() const;
+
+  inline virtual const bool f17() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f17' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] inline virtual const bool f17() const;
+
+  // inline with body
+  bool f18() const
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f18' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f18() const
+  {
+    return true;
+  }
+
+  bool f19() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f19' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f19() const;
+
+  bool f24(size_type) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f24' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f24(size_type) const;
+
+  bool f28(my_unsigned) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f28' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f28(my_unsigned) const;
+
+  bool f29(my_unsigned_reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f29' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f29(my_unsigned_reference) const;
+
+  bool f30(my_unsigned_const_reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f30' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f30(my_unsigned_const_reference) const;
+
+  template <class F>
+  F f37(F a, F b) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f37' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] F f37(F a, F b) const;
+
+  template <class F>
+  bool f38(F a) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f38' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f38(F a) const;
+
+  bool f39(const std::function<bool()> &predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f39' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f39(const std::function<bool()> &predicate) const;
+
+  bool f39a(std::function<bool()> predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f39a' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f39a(std::function<bool()> predicate) const;
+
+  bool f39b(const std::function<bool()> predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f39b' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f39b(const std::function<bool()> predicate) const;
+
+  bool f45(const boost::function<bool()> &predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f45' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f45(const boost::function<bool()> &predicate) const;
+
+  bool f45a(boost::function<bool()> predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f45a' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f45a(boost::function<bool()> predicate) const;
+
+  bool f45b(const boost::function<bool()> predicate) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f45b' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f45b(const boost::function<bool()> predicate) const;
+
+  template <class... Args>
+  bool ParameterPack(Args... args) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'ParameterPack' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool ParameterPack(Args... args) const;
+
+  template <typename... Targs>
+  bool ParameterPack2(Targs... Fargs) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'ParameterPack2' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool ParameterPack2(Targs... Fargs) const;
+
+  bool VariadicFunctionTest(const int &, ...) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'VariadicFunctionTest' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool VariadicFunctionTest(const int &, ...) const;
+
+  static bool not_empty();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'not_empty' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] static bool not_empty();
+
+  explicit operator bool() const { return true; }
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator bool' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] explicit operator bool() const { return true; }
+
+  NoDiscardStruct f50() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f50' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] NoDiscardStruct f50() const;
+};
+
+// Do not add ``[[nodiscard]]`` to Lambda.
+const auto nonConstReferenceType = [] {
+  return true;
+};
+
+auto lambda1 = [](int a, int b) { return a < b; };
+auto lambda1a = [](int a) { return a; };
+auto lambda1b = []() { return true; };
+
+auto get_functor = [](bool check) {
+  return [&](const std::string &sr) -> std::string {
+    if (check) {
+      return std::string();
+    }
+    return std::string();
+  };
+};
+
+// Do not add ``[[nodiscard]]`` to function definition.
+bool Foo::f19() const {
+  return true;
+}
+
+template <class T>
+class Bar {
+public:
+  using value_type = T;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+
+  operator bool() const { return true; }
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator bool' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] operator bool() const { return true; }
+
+  bool empty() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'empty' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool empty() const;
+
+  bool f25(value_type) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f25' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f25(value_type) const;
+
+  bool f27(reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f27' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f27(reference) const;
+
+  typename T::value_type f35() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f35' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] typename T::value_type f35() const;
+
+  T f34() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f34' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] T f34() const;
+
+  bool f31(T) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f31' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f31(T) const;
+
+  bool f33(T &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f33' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f33(T &) const;
+
+  bool f26(const_reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f26' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f26(const_reference) const;
+
+  bool f32(const T &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f32' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f32(const T &) const;
+};
+
+template <typename _Tp, int cn>
+class Vec {
+public:
+  Vec(_Tp v0, _Tp v1); //!< 2-element vector constructor
+
+  Vec cross(const Vec &v) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'cross' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] Vec cross(const Vec &v) const;
+
+  template <typename T2>
+  operator Vec<T2, cn>() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'operator Vec<type-parameter-1-0, cn>' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] operator Vec<T2, cn>() const;
+};
+
+template <class T>
+class Bar2 {
+public:
+  typedef T value_type;
+  typedef value_type &reference;
+  typedef const value_type &const_reference;
+
+  bool f40(value_type) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f40' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f40(value_type) const;
+
+  bool f41(reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f41' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f41(reference) const;
+
+  value_type f42() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f42' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] value_type f42() const;
+
+  typename T::value_type f43() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f43' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] typename T::value_type f43() const;
+
+  bool f44(const_reference) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'f44' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool f44(const_reference) const;
+};
+
+template <class T>
+bool Bar<T>::empty() const {
+  return true;
+}
+
+// don't mark typical ``[[nodiscard]]`` candidates if the class
+// has mutable member variables
+class MutableExample {
+  mutable bool m_isempty;
+
+public:
+  bool empty() const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function 'empty' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+  // CHECK-FIXES{LITERAL}: [[nodiscard]] bool empty() const;
+};
+
+bool f1();
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: function 'f1' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+// CHECK-FIXES{LITERAL}: [[nodiscard]] bool f1();
+
+template <typename T>
+typename T::value f2(T &) noexcept;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: function 'f2' should be marked {{\[\[nodiscard\]\]}} [daedalean-use-nodiscard]
+// CHECK-FIXES{LITERAL}: [[nodiscard]] typename T::value f2(T &) noexcept;
+
+template <typename T>
+[[nodiscard]] typename T::value f3(T &) noexcept;
+
+[[nodiscard]] bool f4();


### PR DESCRIPTION
Updated check to work with both functions and methods and removed a bunch of conditions that simply do not apply for CS.R.5. Instead, added 2 exceptions:
  - preincrement and predecrement operators that return references.
  - assignment operators that return references.