### PR TITLE
Implement daedalean-vararg-functions-must-not-be-used for CS.R.26

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangTidyDaedaleanModule
   ProtectedMustNotBeUsedCheck.cpp
   SwitchStatementCheck.cpp
   UnionsMustNotBeUsedCheck.cpp
+  VarargFunctionsMustNotBeUsedCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -27,6 +27,7 @@
 #include "TernaryOperatorMustNotBeUsedCheck.h"
 #include "TypeConversionsCheck.h"
 #include "UnionsMustNotBeUsedCheck.h"
+#include "VarargFunctionsMustNotBeUsedCheck.h"
 
 using namespace clang::ast_matchers;
 
@@ -76,6 +77,8 @@ public:
         "daedalean-switch-statement");
     CheckFactories.registerCheck<UnionsMustNotBeUsedCheck>(
         "daedalean-unions-must-not-be-used");
+    CheckFactories.registerCheck<VarargFunctionsMustNotBeUsedCheck>(
+        "daedalean-vararg-functions-must-not-be-used");
   }
 };
 

--- a/clang-tools-extra/clang-tidy/daedalean/VarargFunctionsMustNotBeUsedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/VarargFunctionsMustNotBeUsedCheck.cpp
@@ -1,0 +1,171 @@
+//===--- VarargFunctionsMustNotBeUsedCheck.cpp - clang-tidy ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "VarargFunctionsMustNotBeUsedCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/Token.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+const internal::VariadicDynCastAllOfMatcher<Stmt, VAArgExpr> VAArgExpr;
+
+static constexpr StringRef VaArgWarningMessage =
+    "do not use va_arg to define c-style vararg functions; "
+    "use variadic templates instead";
+
+static constexpr StringRef VaArgFuncWarningMessage =
+    "do not define c-style vararg functions; use variadic templates instead";
+
+namespace {
+AST_MATCHER(QualType, isVAList) {
+  ASTContext &Context = Finder->getASTContext();
+  QualType Desugar = Node.getDesugaredType(Context);
+  QualType NodeTy = Node.getUnqualifiedType();
+
+  auto CheckVaList = [](QualType NodeTy, QualType Expected,
+                        const ASTContext &Context) {
+    if (NodeTy == Expected)
+      return true;
+    QualType Desugar = NodeTy;
+    QualType Ty;
+    do {
+      Ty = Desugar;
+      Desugar = Ty.getSingleStepDesugaredType(Context);
+      if (Desugar == Expected)
+        return true;
+    } while (Desugar != Ty);
+    return false;
+  };
+
+  // The internal implementation of __builtin_va_list depends on the target
+  // type. Some targets implements va_list as 'char *' or 'void *'.
+  // In these cases we need to remove all typedefs one by one to check this.
+  using BuiltinVaListKind = TargetInfo::BuiltinVaListKind;
+  BuiltinVaListKind VaListKind = Context.getTargetInfo().getBuiltinVaListKind();
+  if (VaListKind == BuiltinVaListKind::CharPtrBuiltinVaList ||
+      VaListKind == BuiltinVaListKind::VoidPtrBuiltinVaList) {
+    if (CheckVaList(NodeTy, Context.getBuiltinVaListType(), Context))
+      return true;
+  } else if (Desugar ==
+             Context.getBuiltinVaListType().getDesugaredType(Context)) {
+    return true;
+  }
+
+  // We also need to check the implementation of __builtin_ms_va_list in the
+  // same way, because it may differ from the va_list implementation.
+  if (Desugar == Context.getBuiltinMSVaListType().getDesugaredType(Context) &&
+      CheckVaList(NodeTy, Context.getBuiltinMSVaListType(), Context)) {
+    return true;
+  }
+
+  return false;
+}
+
+AST_MATCHER_P(AdjustedType, hasOriginalType,
+              ast_matchers::internal::Matcher<QualType>, InnerType) {
+  return InnerType.matches(Node.getOriginalType(), Finder, Builder);
+}
+
+class VaArgPPCallbacks : public PPCallbacks {
+public:
+  VaArgPPCallbacks(VarargFunctionsMustNotBeUsedCheck *Check) : Check(Check) {}
+
+  void MacroExpands(const Token &MacroNameTok, const MacroDefinition &MD,
+                    SourceRange Range, const MacroArgs *Args) override {
+    if (MacroNameTok.getIdentifierInfo()->getName() == "va_arg") {
+      Check->diag(MacroNameTok.getLocation(), VaArgWarningMessage);
+    }
+  }
+
+private:
+  VarargFunctionsMustNotBeUsedCheck *Check;
+};
+} // namespace
+
+void VarargFunctionsMustNotBeUsedCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(VAArgExpr().bind("va_use"), this);
+
+  Finder->addMatcher(
+      callExpr(callee(functionDecl(isVariadic()))).bind("callvararg"), this);
+
+  // Match on variadic function declarations that have definitions, the
+  // exception is function declaration for SFINAE without definition
+  Finder->addMatcher(
+      functionDecl(allOf(isVariadic(), isDefinition())).bind("varargfunc"),
+      this);
+
+  Finder->addMatcher(
+      varDecl(hasType(qualType(
+                  anyOf(isVAList(), decayedType(hasOriginalType(isVAList()))))))
+          .bind("va_list"),
+      this);
+}
+
+void VarargFunctionsMustNotBeUsedCheck::registerPPCallbacks(
+    const SourceManager &SM, Preprocessor *PP, Preprocessor *ModuleExpanderPP) {
+  PP->addPPCallbacks(std::make_unique<VaArgPPCallbacks>(this));
+}
+
+static bool hasSingleVariadicArgumentWithValue(const CallExpr *C, uint64_t I) {
+  const auto *FDecl = dyn_cast<FunctionDecl>(C->getCalleeDecl());
+  if (!FDecl)
+    return false;
+
+  auto N = FDecl->getNumParams(); // Number of parameters without '...'
+  if (C->getNumArgs() != N + 1)
+    return false; // more/less than one argument passed to '...'
+
+  const auto *IntLit =
+      dyn_cast<IntegerLiteral>(C->getArg(N)->IgnoreParenImpCasts());
+  if (!IntLit)
+    return false;
+
+  if (IntLit->getValue() != I)
+    return false;
+
+  return true;
+}
+
+void VarargFunctionsMustNotBeUsedCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  if (const auto *Matched = Result.Nodes.getNodeAs<CallExpr>("callvararg")) {
+    if (hasSingleVariadicArgumentWithValue(Matched, 0))
+      return;
+    diag(Matched->getExprLoc(), "do not call c-style vararg functions");
+  }
+
+  if (const auto *Matched = Result.Nodes.getNodeAs<Expr>("va_use")) {
+    diag(Matched->getExprLoc(), VaArgWarningMessage);
+  }
+
+  if (const auto *Matched = Result.Nodes.getNodeAs<VarDecl>("va_list")) {
+    auto SR = Matched->getSourceRange();
+    if (SR.isInvalid())
+      return; // some implicitly generated builtins take va_list
+    diag(SR.getBegin(), "do not declare variables of type va_list; "
+                        "use variadic templates instead");
+  }
+
+  if (const auto *Matched =
+          Result.Nodes.getNodeAs<FunctionDecl>("varargfunc")) {
+    diag(Matched->getLocation(), VaArgFuncWarningMessage);
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/VarargFunctionsMustNotBeUsedCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/VarargFunctionsMustNotBeUsedCheck.h
@@ -1,0 +1,40 @@
+//===--- VarargFunctionsMustNotBeUsedCheck.h - clang-tidy -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_VARARGFUNCTIONSMUSTNOTBEUSEDCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_VARARGFUNCTIONSMUSTNOTBEUSEDCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// This check flags all calls to c-style variadic functions and all use
+/// of va_arg.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-vararg-functions-must-not-be-used.html
+class VarargFunctionsMustNotBeUsedCheck : public ClangTidyCheck {
+public:
+  VarargFunctionsMustNotBeUsedCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_VARARGFUNCTIONSMUSTNOTBEUSEDCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -255,6 +255,12 @@ New checks
 
   FIXME: add release notes.
 
+- New :doc:`daedalean-vararg-functions-must-not-be-used
+  <clang-tidy/checks/daedalean-vararg-functions-must-not-be-used>` check.
+
+  Warns if c-style vararg functions are defined. Note that they can be declared for SFINAE,
+  but not defined.
+
 - New :doc:`misc-misleading-bidirectional <clang-tidy/checks/misc-misleading-bidirectional>` check.
 
   Inspects string literal and comments for unterminated bidirectional Unicode

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-vararg-functions-must-not-be-used.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-vararg-functions-must-not-be-used.rst
@@ -1,0 +1,14 @@
+.. title:: clang-tidy - daedalean-vararg-functions-must-not-be-used
+
+daedalean-vararg-functions-must-not-be-used
+===========================================
+
+This check flags all calls to c-style vararg functions and all use of
+``va_arg``.
+
+To allow for SFINAE use of vararg functions, a call is not flagged if a literal
+0 is passed as the only vararg argument.
+
+Passing to varargs assumes the correct type will be read. This is fragile
+because it cannot generally be enforced to be safe in the language and so relies
+on programmer discipline to get it right.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -187,7 +187,8 @@ Clang-Tidy Checks
    `daedalean-switch-statement <daedalean-switch-statement.html>`_,
    `daedalean-ternary-operator-must-not-be-used <daedalean-ternary-operator-must-not-be-used.html>`_,
    `daedalean-type-conversions <daedalean-type-conversions.html>`_,
-   `daedalean-unions-must-not-be-used <daedalean-unions-must-not-be-used.html>`_, "Yes"
+   `daedalean-unions-must-not-be-used <daedalean-unions-must-not-be-used.html>`_,
+   `daedalean-vararg-functions-must-not-be-used <daedalean-vararg-functions-must-not-be-used.html>`_, "Yes"
    `darwin-avoid-spinlock <darwin-avoid-spinlock.html>`_,
    `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_, "Yes"
    `fuchsia-default-arguments-calls <fuchsia-default-arguments-calls.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-vararg-functions-must-not-be-used.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-vararg-functions-must-not-be-used.cpp
@@ -1,0 +1,79 @@
+// RUN: %check_clang_tidy %s daedalean-vararg-functions-must-not-be-used %t
+
+void f(int i);
+void f_vararg(int i, ...);
+
+struct C {
+  void g_vararg(...) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: do not define c-style vararg functions; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+  void g(const char *);
+} c;
+
+template <typename... P>
+void cpp_vararg(P... p) {}
+
+void check() {
+  f_vararg(1, 7, 9);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+  c.g_vararg("foo");
+  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+
+  f(3);                // OK
+  c.g("foo");          // OK
+  cpp_vararg(1, 7, 9); // OK
+}
+
+template <typename T>
+void CallFooIfAvailableImpl(T &t, ...) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: do not define c-style vararg functions; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+}
+template <typename T>
+void CallFooIfAvailableImpl(T &t, decltype(t.foo()) *) {
+  t.foo();
+}
+template <typename T>
+void CallFooIfAvailable(T &t) {
+  CallFooIfAvailableImpl(t, 0); // OK to call variadic function when the argument is a literal 0
+}
+
+#include <stdarg.h>
+
+void my_printf(const char *format, ...);
+
+void my_printf(const char *format, ...) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: do not define c-style vararg functions; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+  va_list ap;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: do not declare variables of type va_list; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+  va_start(ap, format);
+  va_list n;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: do not declare variables of type va_list; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+  va_copy(n, ap);
+  int i = va_arg(ap, int);
+  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: do not use va_arg to define c-style vararg functions; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+  va_end(ap);
+}
+
+int my_vprintf(const char *format, va_list arg);
+// CHECK-MESSAGES: :[[@LINE-1]]:36: warning: do not declare variables of type va_list; use variadic templates instead [daedalean-vararg-functions-must-not-be-used]
+
+void ignoredBuiltinsTest() {
+  (void)__builtin_assume_aligned(0, 8);
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+  (void)__builtin_fpclassify(0, 0, 0, 0, 0, 0.f);
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+  (void)__builtin_isinf_sign(0.f);
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+  (void)__builtin_prefetch(nullptr);
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not call c-style vararg functions [daedalean-vararg-functions-must-not-be-used]
+}
+
+// Declaring a variadic function but not defining it anywhere is fine, they can be used for SFINAE.
+void declaredButNotDefinedAnywhere(const char *format, ...);
+
+// Some implementations of __builtin_va_list and __builtin_ms_va_list desugared
+// as 'char *' or 'void *'. This test checks whether we are handling this case
+// correctly and not generating false positives.
+void no_false_positive_desugar_va_list(char *in) {
+  char *tmp1 = in;
+  void *tmp2 = in;
+}


### PR DESCRIPTION
Unlike the `cppcoreguidelines-pro-type-varargs` check, do not just warn 
on usage of vararg functions, but also on their definition. 
Declaration of vararg functions is fine as they can be used
for SFINAE. However, defining a vararg function triggers a clang-tidy
warning.

In addition, it also:
- Removes exceptions to builtin varargs, so that the user needs to
explicitly silence the lint with an exception to the rule (if
applicable).
- Flags functions that take a `va_list` as a parameter, not just 
variable declarations.