### PR TITLE
Fix crash in daedalean-operator-overloading-check

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/OperatorOverloadingCheck.cpp
@@ -114,14 +114,16 @@ void OperatorOverloadingCheck::check(const MatchFinder::MatchResult &Result) {
   case OO_StarEqual:
     [[fallthrough]];
   case OO_PercentEqual: {
-    checkReturnSelf(method->getDefinition()->getBody());
+    if (method->isDefined()) {
+      checkReturnSelf(method->getDefinition()->getBody());
+    }
     break;
   }
   case OO_Amp:
-      if (function->getNumParams() != 0) { // Skip binary form
-        break;
-      }
-      [[fallthrough]];
+    if (function->getNumParams() != 0) { // Skip binary form
+      break;
+    }
+    [[fallthrough]];
   case OO_AmpAmp:
     [[fallthrough]];
   case OO_PipePipe:

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-operator-overloading.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-operator-overloading.cpp
@@ -2,86 +2,89 @@
 
 class C {
 public:
-    bool operator &&(const C&) const;
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator&&' is disallowed [daedalean-operator-overloading]
-    bool operator ||(const C&) const;
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator||' is disallowed [daedalean-operator-overloading]
-    C* operator&();
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: overloading 'operator&' is disallowed [daedalean-operator-overloading]
-    C operator &(const C&);
-    int operator[](int);
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
+  bool operator&&(const C &) const;
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: overloading 'operator&&' is disallowed [daedalean-operator-overloading]
+  bool operator||(const C &) const;
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: overloading 'operator||' is disallowed [daedalean-operator-overloading]
+  C *operator&();
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: overloading 'operator&' is disallowed [daedalean-operator-overloading]
+  C operator&(const C &);
+  int operator[](int);
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
 
-    bool operator==(const C&);
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If == overloaded, != MUST be overloaded as well [daedalean-operator-overloading]
-    bool operator!=(const int);
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If != overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
+  bool operator==(const C &);
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: If == overloaded, != MUST be overloaded as well [daedalean-operator-overloading]
+  bool operator!=(const int);
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: If != overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
 
-    bool operator==(float);
-    bool operator!=(float);
+  bool operator==(float);
+  bool operator!=(float);
 
-    C & operator=(int a) {
-      if (a == 1) {
-        return *(new C);
-        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
-      } else if (a == 2) {
-        C * v = this;
-        return *v;
-        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
-      } else if (a == 3) {
-        C &v = *this;
-        return v;
-        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
-      }
-      return *this;
+  C &operator=(int a) {
+    if (a == 1) {
+      return *(new C);
+      // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
+    } else if (a == 2) {
+      C *v = this;
+      return *v;
+      // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
+    } else if (a == 3) {
+      C &v = *this;
+      return v;
+      // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Assignment operator must return reference to this  [daedalean-operator-overloading]
     }
+    return *this;
+  }
+
+  // Must not crash
+  C &operator=(float a);
 };
 
 class C2 {
-    int operator[](int);
-    int operator[](int) const;
-    int operator[](int&);
-    //  CHECK-MESSAGES: :[[@LINE-1]]:5: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
-    bool operator==(char);
+  int operator[](int);
+  int operator[](int) const;
+  int operator[](int &);
+  //  CHECK-MESSAGES: :[[@LINE-1]]:3: warning: If operator[] overloaded with non-const version, const version MUST be present. [daedalean-operator-overloading]
+  bool operator==(char);
 };
 
-bool operator==(const C2&, const C&);
+bool operator==(const C2 &, const C &);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If == overloaded, != MUST be overloaded as well [daedalean-operator-overloading]
-bool operator!=(const C2&, const int);
+bool operator!=(const C2 &, const int);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If != overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
 
-bool operator<(const C2&, const C&);
+bool operator<(const C2 &, const C &);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If < overloaded, > MUST be overloaded as well [daedalean-operator-overloading]
-bool operator>(const C2&, const int);
+bool operator>(const C2 &, const int);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If > overloaded, < MUST be overloaded as well [daedalean-operator-overloading]
 
-bool operator<=(const C2&, const C&);
+bool operator<=(const C2 &, const C &);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If <= overloaded, >= MUST be overloaded as well [daedalean-operator-overloading]
-bool operator>=(const C2&, const int);
+bool operator>=(const C2 &, const int);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If >= overloaded, <= MUST be overloaded as well [daedalean-operator-overloading]
 //  CHECK-MESSAGES: :[[@LINE-2]]:1: warning: If >= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
 
-bool operator<=(const C2&, float);
+bool operator<=(const C2 &, float);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If <= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
-bool operator>=(const C2&, float);
+bool operator>=(const C2 &, float);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If >= overloaded, == MUST be overloaded as well [daedalean-operator-overloading]
 
-bool operator<(const C2&, double);
-bool operator>(const C2&, double);
-bool operator!=(const C2&, double);
-bool operator==(const C2&, double);
+bool operator<(const C2 &, double);
+bool operator>(const C2 &, double);
+bool operator!=(const C2 &, double);
+bool operator==(const C2 &, double);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: If == and < overloaded, <= MUST be overloaded as well [daedalean-operator-overloading]
 
-bool operator!=(const C2&, char);
+bool operator!=(const C2 &, char);
 
-bool operator==(const C2&, const C2&);
-bool operator!=(const C2&, const C2&);
-bool operator<(const C2&, const C2&);
-bool operator>(const C2&, const C2&);
-bool operator<=(const C2&, const C2&);
-bool operator>=(const C2&, const C2&);
+bool operator==(const C2 &, const C2 &);
+bool operator!=(const C2 &, const C2 &);
+bool operator<(const C2 &, const C2 &);
+bool operator>(const C2 &, const C2 &);
+bool operator<=(const C2 &, const C2 &);
+bool operator>=(const C2 &, const C2 &);
 
-bool operator &&(const C&, const C&);
+bool operator&&(const C &, const C &);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: overloading 'operator&&' is disallowed [daedalean-operator-overloading]
-bool operator ||(const C&, const C&);
+bool operator||(const C &, const C &);
 //  CHECK-MESSAGES: :[[@LINE-1]]:1: warning: overloading 'operator||' is disallowed [daedalean-operator-overloading]


### PR DESCRIPTION
a method definition can be nullptr if it is not part of the translation
unit being parsed.