### PR TITLE
Implement daedalean-use-noexcept check

### DIFF
--- a/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/daedalean/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangTidyDaedaleanModule
   SwitchStatementCheck.cpp
   UnionsMustNotBeUsedCheck.cpp
   VarargFunctionsMustNotBeUsedCheck.cpp
+  UseNoexceptCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/DaedaleanTidyModule.cpp
@@ -29,6 +29,7 @@
 #include "TernaryOperatorMustNotBeUsedCheck.h"
 #include "TypeConversionsCheck.h"
 #include "UnionsMustNotBeUsedCheck.h"
+#include "UseNoexceptCheck.h"
 #include "VarargFunctionsMustNotBeUsedCheck.h"
 
 using namespace clang::ast_matchers;
@@ -83,6 +84,7 @@ public:
         "daedalean-switch-statement");
     CheckFactories.registerCheck<UnionsMustNotBeUsedCheck>(
         "daedalean-unions-must-not-be-used");
+    CheckFactories.registerCheck<UseNoexceptCheck>("daedalean-use-noexcept");
     CheckFactories.registerCheck<VarargFunctionsMustNotBeUsedCheck>(
         "daedalean-vararg-functions-must-not-be-used");
   }

--- a/clang-tools-extra/clang-tidy/daedalean/UseNoexceptCheck.cpp
+++ b/clang-tools-extra/clang-tidy/daedalean/UseNoexceptCheck.cpp
@@ -1,0 +1,60 @@
+//===--- UseNoexceptCheck.cpp - clang-tidy --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseNoexceptCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+void UseNoexceptCheck::registerMatchers(MatchFinder *Finder) {
+  auto isPartOfLambda = cxxMethodDecl(ofClass(isLambda()));
+  Finder->addMatcher(
+      functionDecl(unless(anyOf(isNoThrow(), isPartOfLambda, cxxMethodDecl())))
+          .bind("function"),
+      this);
+  Finder->addMatcher(
+      cxxMethodDecl(unless(anyOf(isNoThrow(), isPartOfLambda))).bind("method"),
+      this);
+  Finder->addMatcher(
+      cxxMethodDecl(allOf(ofClass(isLambda()), hasOverloadedOperatorName("()")),
+                    unless(isNoThrow()))
+          .bind("lambda"),
+      this);
+}
+
+void UseNoexceptCheck::check(const MatchFinder::MatchResult &Result) {
+  if (const auto *MatchedDecl =
+          Result.Nodes.getNodeAs<FunctionDecl>("function")) {
+    diag(MatchedDecl->getLocation(), "Function %0 should be noexcept")
+        << MatchedDecl;
+    diag(MatchedDecl->getLocation(), "insert 'noexcept'", DiagnosticIDs::Note);
+  }
+
+  if (const auto *MatchedDecl =
+          Result.Nodes.getNodeAs<CXXMethodDecl>("method")) {
+    diag(MatchedDecl->getLocation(), "Method %0 should be noexcept")
+        << MatchedDecl;
+    diag(MatchedDecl->getLocation(), "insert 'noexcept'", DiagnosticIDs::Note);
+  }
+
+  if (const auto *MatchedDecl =
+          Result.Nodes.getNodeAs<CXXMethodDecl>("lambda")) {
+    diag(MatchedDecl->getLocation(), "Lambda should be noexcept");
+    diag(MatchedDecl->getLocation(), "insert 'noexcept'", DiagnosticIDs::Note);
+  }
+}
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/daedalean/UseNoexceptCheck.h
+++ b/clang-tools-extra/clang-tidy/daedalean/UseNoexceptCheck.h
@@ -1,0 +1,35 @@
+//===--- UseNoexceptCheck.h - clang-tidy ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENOEXCEPTCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENOEXCEPTCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace daedalean {
+
+/// Finds function/method declarations and makes sure they have a noexcept
+/// specifier or warns the user.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/daedalean-use-noexcept.html
+class UseNoexceptCheck : public ClangTidyCheck {
+public:
+  UseNoexceptCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace daedalean
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_DAEDALEAN_USENOEXCEPTCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -271,6 +271,11 @@ New checks
 - New :doc:`daedalean-unions-must-not-be-used
   <clang-tidy/checks/daedalean-unions-must-not-be-used>` check.
 
+  Finds function/method declarations and makes sure they have a noexcept specifier or warns the user.
+
+- New :doc:`daedalean-use-noexcept
+  <clang-tidy/checks/daedalean-use-noexcept>` check.
+
   FIXME: add release notes.
 
 - New :doc:`daedalean-vararg-functions-must-not-be-used

--- a/clang-tools-extra/docs/clang-tidy/checks/daedalean-use-noexcept.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/daedalean-use-noexcept.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - daedalean-use-noexcept
+
+daedalean-use-noexcept
+======================
+
+Finds function/method declarations and makes sure they have a noexcept specifier or warns the user

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -190,6 +190,7 @@ Clang-Tidy Checks
    `daedalean-ternary-operator-must-not-be-used <daedalean-ternary-operator-must-not-be-used.html>`_,
    `daedalean-type-conversions <daedalean-type-conversions.html>`_,
    `daedalean-unions-must-not-be-used <daedalean-unions-must-not-be-used.html>`_,
+   `daedalean-use-noexcept <daedalean-use-noexcept.html>`_, "Yes"
    `daedalean-vararg-functions-must-not-be-used <daedalean-vararg-functions-must-not-be-used.html>`_,
    `darwin-avoid-spinlock <darwin-avoid-spinlock.html>`_,
    `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_, "Yes"
@@ -350,7 +351,6 @@ Clang-Tidy Checks
    `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
    `readability-use-anyofallof <readability-use-anyofallof.html>`_,
    `zircon-temporary-objects <zircon-temporary-objects.html>`_,
-
 
 .. csv-table:: Aliases..
    :header: "Name", "Redirect", "Offers fixes"

--- a/clang-tools-extra/test/clang-tidy/checkers/daedalean-use-noexcept.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/daedalean-use-noexcept.cpp
@@ -1,0 +1,28 @@
+// RUN: %check_clang_tidy %s daedalean-use-noexcept %t
+
+class S {
+public:
+  S();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Method 'S' should be noexcept [daedalean-use-noexcept]
+  S(const S &)
+  noexcept = default;
+
+  bool operator==(const S &) const noexcept;
+  bool operator!=(const S &) const;
+  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: Method 'operator!=' should be noexcept [daedalean-use-noexcept]
+};
+
+void f() noexcept;
+
+void f2();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Function 'f2' should be noexcept [daedalean-use-noexcept]
+//
+void func() noexcept {
+  auto noexceptLambda = []() noexcept {
+
+  };
+
+  auto lambda = []() {
+    // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: Lambda should be noexcept [daedalean-use-noexcept]
+  };
+}


### PR DESCRIPTION
The nice thing about clang-tidy checks is that they show up in clangd as well, so the user should fix missing noexcept specifiers before reaching review stage and remove some boilerplate comments/fixes from the reviews.