### PR TITLE
Fix magic-numbers checker

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
@@ -119,9 +119,13 @@ void MagicNumbersCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void MagicNumbersCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(integerLiteral().bind("integer"), this);
+  Finder->addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
+                              integerLiteral().bind("integer")),
+                     this);
   if (!IgnoreAllFloatingPointValues)
-    Finder->addMatcher(floatLiteral().bind("float"), this);
+    Finder->addMatcher(
+        traverse(TK_IgnoreUnlessSpelledInSource, floatLiteral().bind("float")),
+        this);
 }
 
 void MagicNumbersCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.h
@@ -78,10 +78,6 @@ private:
         CharSourceRange::getTokenRange(MatchedLiteral->getSourceRange()),
         *Result.SourceManager, getLangOpts());
 
-    const auto parents = Result.Context->getParents(*MatchedLiteral);
-
-    const auto val = parents[0].template get<CallExpr>();
-
     diag(MatchedLiteral->getLocation(),
          "%0 is a magic number; consider replacing it with a named constant")
         << LiteralSourceText;


### PR DESCRIPTION
magic-numbers produced false-positives on compiler-generated code for defaulted member functions